### PR TITLE
Update numba_sysinfo.py: Fix error when using rocm

### DIFF
--- a/numba/misc/numba_sysinfo.py
+++ b/numba/misc/numba_sysinfo.py
@@ -403,12 +403,12 @@ def get_sysinfo():
         sys_info[_hsa_agents_count] = len(hsa.agents)
         agents = []
         for i, agent in enumerate(hsa.agents):
-            agents += {
+            agents.append({
                 'Agent id': i,
                 'Vendor': decode(agent.vendor_name),
                 'Name': decode(agent.name),
                 'Type': agent.device,
-            }
+            })
         sys_info[_hsa_agents] = agents
 
         _dgpus = []


### PR DESCRIPTION
numba -s fails with: AttributeError: 'str' object has no attribute 'items' #5947
The code in numba/misc/numba_sysinfo.py starting at line 406 is:
```
           agents += {
                'Agent id': i,
                'Vendor': decode(agent.vendor_name),
                'Name': decode(agent.name),
                'Type': agent.device,
            }
```
and should be:
```
            agents.append( {
                'Agent id': i,
                'Vendor': decode(agent.vendor_name),
                'Name': decode(agent.name),
                'Type': agent.device,
            })
```
Tested on my rocm machine with: numba -s

Kind regards,
Tony
